### PR TITLE
fix: use CA Bundle when connecting to OAuth provider

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,11 @@
 name: test
-on: [workflow_dispatch, push, pull_request]
+on:
+    pull_request:
+        types: [opened, synchronize, reopened]
+    push:
+        branches:
+            - main
+            - release-*
 jobs:
   build:
     name: Build and Lint

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,35 @@
+name: test
+on: [workflow_dispatch, push, pull_request]
+jobs:
+  build:
+    name: Build and Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Checkout code
+      # https://github.com/actions/checkout
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      # Setup GoLang build environment
+      # https://github.com/actions/setup-go
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      # Download dependencies
+      - run: go mod download
+
+      # Build Go binary
+      - run: go build ./...
+
+      - run: go vet ./...
+
+      # Run Go linters
+      # https://github.com/golangci/golangci-lint-action
+      - name: Run linters
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# v1.1.0
+## Chores
+- Bump oauth2 from 0.21.0 to 0.27.0 (requires Go >= 1.23.0)
+## Fixes
+- Fixes an issue where the OAuth token source did not use the provided CA trust bundle when fetching tokens, which could lead to TLS errors in environments with custom CAs.
+
+# v1.0.2
+## Chores
+- Bump oauth2 from 0.20.0 to 0.21.0
+
+# v1.0.1
+## Chores
+- Rename `GetHttpClient` to `GetHTTPClient`
+
+# v1.0.0
+- Initial release of the EJBCA Go Client SDK, providing a client for interacting with EJBCA's REST API.

--- a/api/ejbca/auth.go
+++ b/api/ejbca/auth.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Keyfactor
+Copyright 2026 Keyfactor
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -134,22 +134,37 @@ func (b *OAuthAuthenticatorBuilder) Build() (Authenticator, error) {
 	}
 
 	if len(b.caCertificates) > 0 {
-		tlsConfig := &tls.Config{
+		// Strict TLS for EJBCA: only the supplied CA bundle.
+		ejbcaTLSConfig := &tls.Config{
 			Renegotiation: tls.RenegotiateOnceAsClient,
+			RootCAs:       x509.NewCertPool(),
 		}
-
-		tlsConfig.RootCAs = x509.NewCertPool()
 		for _, caCert := range b.caCertificates {
-			tlsConfig.RootCAs.AddCert(caCert)
+			ejbcaTLSConfig.RootCAs.AddCert(caCert)
 		}
+		ejbcaTransport := http.DefaultTransport.(*http.Transport).Clone()
+		ejbcaTransport.TLSClientConfig = ejbcaTLSConfig
+		ejbcaTransport.TLSHandshakeTimeout = 10 * time.Second
 
-		customTransport := http.DefaultTransport.(*http.Transport).Clone()
-		customTransport.TLSClientConfig = tlsConfig
-		customTransport.TLSHandshakeTimeout = 10 * time.Second
+		// Permissive TLS for the OAuth provider: system trust bundle + supplied CA bundle.
+		// This allows publicly-trusted OAuth providers (Okta, Entra, etc.) to work without
+		// extra configuration, while still supporting private OAuth providers via the CA bundle.
+		oauthRootCAs, err := x509.SystemCertPool()
+		if err != nil {
+			oauthRootCAs = x509.NewCertPool()
+		}
+		for _, caCert := range b.caCertificates {
+			oauthRootCAs.AddCert(caCert)
+		}
+		oauthProviderTransport := http.DefaultTransport.(*http.Transport).Clone()
+		oauthProviderTransport.TLSClientConfig = &tls.Config{
+			Renegotiation: tls.RenegotiateOnceAsClient,
+			RootCAs:       oauthRootCAs,
+		}
+		oauthProviderTransport.TLSHandshakeTimeout = 10 * time.Second
 
-		// Wrap the custom transport with the oauth2.Transport
-		oauthTransport.Base = customTransport
-		ctx = context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Transport: customTransport})
+		oauthTransport.Base = ejbcaTransport
+		ctx = context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Transport: oauthProviderTransport})
 	}
 
 	oauthTransport.Source = config.TokenSource(ctx)

--- a/api/ejbca/auth.go
+++ b/api/ejbca/auth.go
@@ -33,6 +33,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -62,6 +63,10 @@ type OAuthAuthenticatorBuilder struct {
 	scopes            []string
 	caCertificatePath string
 	caCertificates    []*x509.Certificate
+
+	// unexported: lazily initialized token source and mutex to protect it
+	tokenSource oauth2.TokenSource
+	tsMu sync.Mutex
 }
 
 func NewOAuthAuthenticatorBuilder() *OAuthAuthenticatorBuilder {
@@ -119,10 +124,10 @@ func (b *OAuthAuthenticatorBuilder) Build() (Authenticator, error) {
 		}
 	}
 
-	tokenSource := config.TokenSource(context.Background())
+	ctx := context.Background()
+
 	oauthTransport := &oauth2.Transport{
 		Base:   http.DefaultTransport,
-		Source: tokenSource,
 	}
 
 	if b.caCertificates == nil {
@@ -149,7 +154,16 @@ func (b *OAuthAuthenticatorBuilder) Build() (Authenticator, error) {
 
 		// Wrap the custom transport with the oauth2.Transport
 		oauthTransport.Base = customTransport
+		ctx = context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Transport: customTransport})
 	}
+
+	// Lazily initialize the token source and cache it
+	b.tsMu.Lock()
+	if b.tokenSource == nil {
+		b.tokenSource = config.TokenSource(ctx)
+	}
+	oauthTransport.Source = b.tokenSource
+	b.tsMu.Unlock()
 
 	client := &http.Client{
 		Transport: oauthTransport,

--- a/api/ejbca/auth.go
+++ b/api/ejbca/auth.go
@@ -63,10 +63,6 @@ type OAuthAuthenticatorBuilder struct {
 	scopes            []string
 	caCertificatePath string
 	caCertificates    []*x509.Certificate
-
-	// unexported: lazily initialized token source and mutex to protect it
-	tokenSource oauth2.TokenSource
-	tsMu sync.Mutex
 }
 
 func NewOAuthAuthenticatorBuilder() *OAuthAuthenticatorBuilder {
@@ -157,13 +153,7 @@ func (b *OAuthAuthenticatorBuilder) Build() (Authenticator, error) {
 		ctx = context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Transport: customTransport})
 	}
 
-	// Lazily initialize the token source and cache it
-	b.tsMu.Lock()
-	if b.tokenSource == nil {
-		b.tokenSource = config.TokenSource(ctx)
-	}
-	oauthTransport.Source = b.tokenSource
-	b.tsMu.Unlock()
+	oauthTransport.Source = config.TokenSource(ctx)
 
 	client := &http.Client{
 		Transport: oauthTransport,

--- a/api/ejbca/auth.go
+++ b/api/ejbca/auth.go
@@ -33,7 +33,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"golang.org/x/oauth2"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/Keyfactor/ejbca-go-client-sdk
 
-go 1.19
+go 1.23.0
 
-require golang.org/x/oauth2 v0.21.0
+require golang.org/x/oauth2 v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=
-golang.org/x/oauth2 v0.21.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=


### PR DESCRIPTION
Currently, requests to the OAuth provider are using only the system's trust store and not the CA bundle provided to the instance. So, if the OAuth provider is not using a publicly trusted cert, the requests fail to the OAuth provider.